### PR TITLE
[FEATURE-1] Add disease description logic

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,9 @@ OUTPUT_DIR = os.path.join(SCRIPT_DIR, "output")
 # DISEASE_SCOPE_LIMIT if value is present processes first variable value number of ICD diseases
 # e.g. DISEASE_SCOPE_LIMIT = 20 would process first 20 ICD diseases in the .csv input file
 DISEASE_SCOPE_LIMIT = None
+# USE_DISEASE_DESCRIPTION if value 'True' and description is present, it provides
+# disease description context to the queried OpenAI API
+USE_DISEASE_DESCRIPTION = False
 # API_KEY used for accessing OpenAI APi, is stored within system environment variables by default
 # if needed this logic can be changed depending on the need, e.g. fetch key from the external service
 API_KEY = os.environ.get("OPENAI_API_KEY")
@@ -44,7 +47,8 @@ USER_PROMPT_TEMPLATE = (
     "ICD code: {code}\n"
     "ICD parent code: {parent_code}\n"
     "Disease name: {name}\n\n"
-    "AVAILABLE NHANES FEATURES (no patient values):\n"
-    "{features_json}\n\n"
+    "Disease description (if empty then not present): {disease_description}\n\n"
+    "AVAILABLE NHANES PARAMETER FEATURES (no patient values):\n"
+    "{parameters_json}\n\n"
     "Decide feasibility strictly based on the features above (names and units only)."
 )

--- a/main.py
+++ b/main.py
@@ -7,10 +7,7 @@ if __name__ == "__main__":
     print("🔍 Starting NHANES-informed ICD Likelihood Assessor (feature-availability mode)...")
 
     nhanes_features = load_nhanes_features(NHANES_CSV_PATH)
-    print(f"Loaded {len(nhanes_features)} NHANES parameters, from: {NHANES_CSV_PATH}")
-
     icd_df = load_icd(ICD_CSV_PATH)
-    print(f"Loaded {len(icd_df)} ICD entries, from: {ICD_CSV_PATH}")
 
     if DISEASE_SCOPE_LIMIT is not None:
         icd_df = icd_df.head(DISEASE_SCOPE_LIMIT)

--- a/processing/disease_assessment_processor.py
+++ b/processing/disease_assessment_processor.py
@@ -40,21 +40,21 @@ def append_all_disease_assessment_status(icd_dataframe: DataFrame, nhanes_featur
         code = (row["code"]).strip()
         parent_code = (row["parent_code"]).strip()
         name = (row["name"]).strip()
+        disease_description = (row["disease_description"]).strip() if USE_DISEASE_DESCRIPTION == True else ""
     
         print(f"[{idx}/{len(icd_dataframe)}] Assessing ICD {code} — {name} ...")
     
         user_prompt = USER_PROMPT_TEMPLATE.format(
-            code=code, parent_code=parent_code, name=name, features_json=medical_parameters_json
+            code=code, parent_code=parent_code, name=name, disease_description=disease_description, parameters_json=medical_parameters_json
         )
-    
+
         try:
             possibility, medical_reasoning = fetch_disease_possibility_and_reasoning_values(client, user_prompt)
     
         except Exception as e:
             print(f"   ❌ API error: {e}")
             possibility, medical_reasoning = "Not Possible", f"API error: {e}"
-    
-        common_columns = {"code": code, "parent_code": parent_code, "name": name, "medical_reasoning": medical_reasoning}
+        common_columns = {"code": code, "parent_code": parent_code, "name": name, "disease_description": disease_description, "medical_reasoning": medical_reasoning}
         all_rows.append({**common_columns, "possibility": possibility})
         if possibility == "Possible":
             possible_rows.append(common_columns)

--- a/processing/io_file_processor.py
+++ b/processing/io_file_processor.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Dict
 import pandas as pd
 
-from config import OUTPUT_DIR
+from config import OUTPUT_DIR, ICD_CSV_PATH, NHANES_CSV_PATH, USE_DISEASE_DESCRIPTION
 
 
 def load_nhanes_features(nhanes_csv: str) -> List[Dict[str, str]]:
@@ -20,17 +20,24 @@ def load_nhanes_features(nhanes_csv: str) -> List[Dict[str, str]]:
     if not features:
         raise ValueError("No NHANES features found in the provided CSV.")
 
+    print(f"Loaded {len(features)} NHANES parameters, from: {NHANES_CSV_PATH}")
+
     return features
 
-def load_icd(icd_csv: str) -> pd.DataFrame:
+def load_icd(icd_csv: str):
     try:
         df = pd.read_csv(icd_csv, dtype=str, on_bad_lines="skip").fillna("")
     except Exception as e:
         raise ValueError(f"Error reading ICD CSV: {e}")
 
     required = {"code", "parent_code", "name"}
+    required = {"code", "parent_code", "name","disease_description"} if USE_DISEASE_DESCRIPTION == True else required
+
     if not required.issubset(df.columns):
         raise ValueError(f"ICD CSV missing required columns: {required - set(df.columns)}")
+
+    print(f"Loaded {len(df)} ICD entries, from: {ICD_CSV_PATH}")
+
     return df
 
 def write_csv_result_file(file_name: str, row_list: list[str]):


### PR DESCRIPTION
Added disease description logic i.e. if 'disease_description' column and the values for it are present in the 'icd_codes.csv' the queries to the OpenAPI contain the disease context. This can be switched on and off. 

Generally, from the couple of tests with number of diseases -> N = 50, 150, 253 , results seem to have bit more (around 4%) not possible assesment results more. With 253 actually it has more possible results with description, although that is most probably due to cached context [need to check this as future feature, add flag for enabling/disabling storing previous query context]. 